### PR TITLE
Implement max HP per level

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A FoundryVTT module for the Pathfinder 1st Edition (PF1e) system that enables **
 - XP is tracked separately per class (internally)
 - XP cost for next level is shown on the character sheet
 - "Level Up" buttons are only enabled if the character has sufficient XP
+- Hit points are automatically maximized for each class level
 - Automatically respects system-wide XP progression (Fast, Medium, Slow, Custom Formula)
 - Lightweight and unobtrusive — integrates directly into the standard PF1e character sheet
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -222,8 +222,10 @@ const pf1eParallelLeveling = {
                     return acc;
                 }
 
-                pf1eParallelLeveling.helpers.__applyHpValues(
-                    pf1eParallelLeveling.helpers.getDictionaryFlagByKey(cls,"Hit Die Rolls")?.split(",") ?? [],
+                const maxHpPerLevel = Array(cls.system.level).fill(parseInt(cls.system.hitDie.replace("d", "")));
+
+                return pf1eParallelLeveling.helpers.__applyHpValues(
+                    maxHpPerLevel,
                     cls.system.hitDie,
                     acc);
             }, { "dieTypes": [], "dieValues": [] });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -222,7 +222,14 @@ const pf1eParallelLeveling = {
                     return acc;
                 }
 
-                const maxHpPerLevel = Array(cls.system.level).fill(parseInt(cls.system.hitDie.replace("d", "")));
+                let dieSize;
+                if (typeof cls.system.hitDie === "number") {
+                    dieSize = cls.system.hitDie;
+                } else {
+                    dieSize = parseInt(String(cls.system.hitDie).replace("d", ""));
+                }
+
+                const maxHpPerLevel = Array(cls.system.level).fill(dieSize);
 
                 return pf1eParallelLeveling.helpers.__applyHpValues(
                     maxHpPerLevel,


### PR DESCRIPTION
## Summary
- set hit points to be maximized for each level
- document the max HP behavior in the README

## Testing
- `node -c scripts/main.js`

------
https://chatgpt.com/codex/tasks/task_b_684b05e3a6888322a44018698341f163